### PR TITLE
refactor: bash improvements and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,12 @@ cd dotfiles
 
 ## Running
 
-You can run `./dotfiles.sh` with no arguments provided to configure the system in its entirety, or alternatively, you can pass any of the following environment args to customise
-what should be run:
+`./dotfiles.sh` expects that arguments will be provided to determine which aspects of the system should be configured. This explicitly requires you to read the documentation under `./dotfiles.sh --help` to gain an understanding of the implications of each aspect to be configured. These aspects can be enabled with the following flags:
 
-1. `DOCK=1` will configure the dock using `dockutil`.
+1. `APPS=1` will install brew, associated apps, packages, and casks.
 2. `DEFAULTS=1` will set system-wide defaults using `defaults write`.
-3. `BREW=1` will install brew, and associated packages & casks.
-4. `TEXT_REPLACEMENTS=1` will generate the `Text Substitutions.plist` file that can be dropped into _System Preferences_ > _Keyboard_ > _Text_.
-
-Run `./dotfiles.sh --help` for more info.
+3. `DOCK=1` will configure the dock using `dockutil`.
+4. `TEXT_REPLACEMENTS=1` will generate a `Text Substitutions.plist` file that can be manully dropped into the `Settings.app` > _Keyboard_ > _Text_ pane.
 
 ## Useful resources
 
@@ -27,7 +24,7 @@ Thanks to the following people for inspiration and configuration ideas:
 - [mathiabynens][1], for everyone's favourite dotfiles repository.
 - [carrlos0][3]
 
-Additionally, this repository tries to follow the patterns set out by [dotfiles.github.io][2].
+## Notes
 
 ### Text replacements errata
 
@@ -35,17 +32,17 @@ Text replacements in macOS are backed by CloudKit and synced across your iCloud 
 
 These changes are not synced to iCloud immediately and may require a system restart.
 
-## Todos
+### Todos
 
-_One thing removed is two more things added._
-
-- Implement both Terminal.app and iTerm.app themes.
+- Implement both `Terminal.app` and `iTerm2.app` themes.
 - Create application shortcut adjustements.
 - Properly implement text replacements.
 - Configure the Finder sidebar.
 - Configure Transmission properly.
 - Set the desktop background, even.
-- Configure pmset.
+- Configure `pmset`.
+- Remove prerequisites for both `yarn` and `node` existing on the system to run `dotfiles.sh`.
+- Try to follow the patterns set out by [dotfiles.github.io][2].
 
 [1]: https://github.com/mathiasbynens/dotfiles
 [2]: https://dotfiles.github.io

--- a/dotfiles.sh
+++ b/dotfiles.sh
@@ -31,7 +31,7 @@ as arguments set to 1. An example of this alternative usage is provided below:
 exit 0
 fi
 
-# Define each of the flag that this scipt accepts, setting the value to zero if none is provided.
+# Define each of the flag that this script accepts, setting the value to zero if none is provided.
 APPS="${APPS:-0}"
 DOCK="${DOCK:-0}"
 DEFAULTS="${DEFAULTS:-0}"

--- a/dotfiles.sh
+++ b/dotfiles.sh
@@ -96,7 +96,7 @@ System Preferences > Keyboard > Text.
 fi 
 
 if requires_js_compilation; then
-    rm -rf  ./dist
+    rm -rf ./dist
 fi
 
 # iTerm configuration. `lukeify.itermcolors` is a slightly modified 

--- a/dotfiles.sh
+++ b/dotfiles.sh
@@ -24,6 +24,7 @@ as arguments set to 1. An example of this alternative usage is provided below:
   # Install brew packages and configure defaults
   BREW=1 DEFAULTS=1 ./dotfiles.sh
 ";
+exit 0
 fi
 
 # Assign default values to unassigned arguments.

--- a/dotfiles.sh
+++ b/dotfiles.sh
@@ -101,14 +101,14 @@ fi
 
 # iTerm configuration. `lukeify.itermcolors` is a slightly modified 
 # color theme that is based off `iceberg-dark`.
-cp iterm2/lukeify.itermcolors ~/.config/iterm2/lukeify.itermcolors
+# cp iterm2/lukeify.itermcolors ~/.config/iterm2/lukeify.itermcolors
 
 # Setup neofetch
-cp neofetch.config ~/.config/neofetch/config.conf
+# cp neofetch.config ~/.config/neofetch/config.conf
 
 # Configure our shell
-touch ~/.hushlogin
-cp .zshrc ~/.zshrc
+# touch ~/.hushlogin
+# cp .zshrc ~/.zshrc
 
 # TODO: 
 # #cp .ssh/config ~/.ssh/config


### PR DESCRIPTION
Some minor cleanup and improvements to atomicity.

1. `exit 0` when `--help` is passed as an argument.
2. Removes a stray space when deleting compiled output upon script completion.
3. Renames the `BREW` flag to `APPS`.
4. Renames the `requires_js_compilation` function to `requires_compilation`.
5. Renames the `aspect_should_run` function to `should_run`.
6. Removes the `ALL` catch-all argument.